### PR TITLE
Restored original JsonpController method signatures

### DIFF
--- a/app/controllers/api/AbstractMemberJsonSerializer.java
+++ b/app/controllers/api/AbstractMemberJsonSerializer.java
@@ -3,13 +3,13 @@ package controllers.api;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 
 import org.apache.commons.collections.CollectionUtils;
 
 import java.lang.reflect.Type;
 
+import helpers.JSON;
 import models.Interest;
 import models.Member;
 import models.Session;
@@ -61,6 +61,26 @@ public abstract class AbstractMemberJsonSerializer {
             result.add("interests", interests);
         }
 
+        if (CollectionUtils.size(member.sessions) != 0) {
+            if(details) {
+                JsonArray sessions = new JsonArray();
+                for (Session s : member.sessions) {
+                    JsonObject session = new JsonObject();
+                    session.addProperty("id", s.id);
+                    session.addProperty("title", s.title);
+                    session.addProperty("summary", s.summary);
+                    session.addProperty("description", s.description);
+                    if (s.lang != null) {
+                        result.addProperty("language", s.lang.toString());
+                    }
+                    sessions.add(session);
+                }
+                result.add("sessions", sessions);
+            }
+            else {
+                result.add("sessions", JSON.toJsonArrayOfIds(member.sessions));
+            }
+        }
 
 
         return result;

--- a/app/controllers/api/AbstractMemberJsonSerializer.java
+++ b/app/controllers/api/AbstractMemberJsonSerializer.java
@@ -1,13 +1,19 @@
 package controllers.api;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
-import helpers.JSON;
-import models.Member;
+
 import org.apache.commons.collections.CollectionUtils;
 
 import java.lang.reflect.Type;
+
+import models.Interest;
+import models.Member;
+import models.Session;
+import models.SharedLink;
 
 public abstract class AbstractMemberJsonSerializer {
 
@@ -31,16 +37,31 @@ public abstract class AbstractMemberJsonSerializer {
         result.addProperty("nbConsults", member.nbConsults);
 
         if (CollectionUtils.size(member.sharedLinks) != 0) {
-            result.add("sharedLinks", jsonSerializationContext.serialize(member.sharedLinks));
+            JsonArray sharedLinks = new JsonArray();
+            for (SharedLink sl : member.sharedLinks) {
+                JsonObject link = new JsonObject();
+                link.addProperty("id", sl.id);
+                link.addProperty("name", sl.name);
+                link.addProperty("url", sl.URL);
+                link.addProperty("ordernum", sl.ordernum);
+                sharedLinks.add(link);
+            }
+            result.add("sharedLinks", sharedLinks);
         }
 
         if (CollectionUtils.size(member.interests) != 0) {
-            if (details) {
-                result.add("interests", jsonSerializationContext.serialize(member.interests));
-            } else {
-                result.add("interests", JSON.toJsonArrayOfIds(member.interests));
+            JsonArray interests = new JsonArray();
+            for (Interest i : member.interests) {
+                JsonObject interest = new JsonObject();
+                interest.addProperty("id", i.id);
+                interest.addProperty("name", i.name);
+                interest.addProperty("url", ApiUrl.getInterestUrl(i.id));
+                interests.add(interest);
             }
+            result.add("interests", interests);
         }
+
+
 
         return result;
     }

--- a/app/controllers/api/ApiMembers.java
+++ b/app/controllers/api/ApiMembers.java
@@ -1,50 +1,51 @@
 package controllers.api;
 
 import com.google.gson.JsonSerializer;
-import models.*;
 
 import java.util.List;
 
+import models.ConferenceEvent;
+import models.Member;
+import models.Sponsor;
+import models.Staff;
+import models.Talk;
+import models.Vote;
+
 public class ApiMembers extends JsonpController {
 
-    private static JsonSerializer MEMBER_SERIALIZERS[] = new JsonSerializer[] {
-            new MemberJsonSerializer(false),
-            new SponsorJsonSerializer(false),
-            new StaffJsonSerializer(false),
-            new InterestJsonSerializer(),
-            new SharedLinkJsonSerializer()
-    };
+    private static JsonSerializer DETAILED_SPONSOR_SERIALIZER = new SponsorJsonSerializer(true);
+    private static JsonSerializer DETAILED_STAFF_SERIALIZER = new StaffJsonSerializer(true);
+    private static JsonSerializer DETAILED_MEMBER_SERIALIZER = new MemberJsonSerializer(true);
+    private static JsonSerializer SPONSOR_SERIALIZER = new SponsorJsonSerializer(false);
+    private static JsonSerializer STAFF_SERIALIZER = new StaffJsonSerializer(false);
+    private static JsonSerializer MEMBER_SERIALIZER = new MemberJsonSerializer(false);
+    private static JsonSerializer TALK_SERIALIZER = new TalkJsonSerializer(true);
 
-    private static JsonSerializer DETAILED_MEMBER_SERIALIZERS[] = new JsonSerializer[] {
-            new MemberJsonSerializer(true),
-            new SponsorJsonSerializer(true),
-            new StaffJsonSerializer(true),
-            new InterestJsonSerializer(),
-            new SharedLinkJsonSerializer()
-    };
-
-    private static JsonSerializer TALK_SERIALIZERS[] = new JsonSerializer[] {
-            new TalkJsonSerializer(true),
-            new LightningTalkJsonSerializer(true),
-    };
 
     public static void speakers(boolean details) {
         List<Member> speakers = Talk.findAllSpeakersOn(ConferenceEvent.CURRENT);
-        renderJSON(speakers, getSerializers(details));
+        for (Member m : speakers) {
+            m.sessions = null;
+        }
+        renderJSON(Member.class, speakers, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
     public static void sponsors(boolean details) {
         List<Sponsor> sponsors = Sponsor.findOn(ConferenceEvent.CURRENT);
-        renderJSON(sponsors, getSerializers(details));
+        renderJSON(Sponsor.class, sponsors, details ? DETAILED_SPONSOR_SERIALIZER : SPONSOR_SERIALIZER);
     }
+
     public static void staff(boolean details) {
         List<Staff> staff = Staff.findAll();
-        renderJSON(staff, getSerializers(details));
+        renderJSON(Staff.class, staff, details ? DETAILED_STAFF_SERIALIZER : STAFF_SERIALIZER);
     }
 
     public static void members(boolean details) {
         List<Member> members = Member.findAll();
-        renderJSON(members, getSerializers(details));
+        for (Member m : members) {
+            m.sessions = null;
+        }
+        renderJSON(Member.class, members, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
     public static void member(long id, boolean details) {
@@ -59,12 +60,9 @@ public class ApiMembers extends JsonpController {
 
     private static void member(Member member, boolean details) {
         notFoundIfNull(member);
-        renderJSON(member, getSerializers(details));
+        renderJSON(Member.class, member, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
-    private static JsonSerializer[] getSerializers(boolean details) {
-        return details ? DETAILED_MEMBER_SERIALIZERS : MEMBER_SERIALIZERS;
-    }
 
     public static void favorites(long memberId) {
         Member member = Member.findById(memberId);
@@ -79,6 +77,6 @@ public class ApiMembers extends JsonpController {
     private static void favorites(Member member) {
         notFoundIfNull(member);
         List<Talk> favorites = Vote.findFavoriteTalksByMemberOn(member, ConferenceEvent.CURRENT);
-        renderJSON(favorites, TALK_SERIALIZERS);
+        renderJSON(Talk.class, favorites, TALK_SERIALIZER);
     }
 }

--- a/app/controllers/api/ApiMembers.java
+++ b/app/controllers/api/ApiMembers.java
@@ -24,9 +24,6 @@ public class ApiMembers extends JsonpController {
 
     public static void speakers(boolean details) {
         List<Member> speakers = Talk.findAllSpeakersOn(ConferenceEvent.CURRENT);
-        for (Member m : speakers) {
-            m.sessions = null;
-        }
         renderJSON(Member.class, speakers, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
@@ -42,9 +39,6 @@ public class ApiMembers extends JsonpController {
 
     public static void members(boolean details) {
         List<Member> members = Member.findAll();
-        for (Member m : members) {
-            m.sessions = null;
-        }
         renderJSON(Member.class, members, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 

--- a/app/controllers/api/ApiMembers.java
+++ b/app/controllers/api/ApiMembers.java
@@ -24,22 +24,22 @@ public class ApiMembers extends JsonpController {
 
     public static void speakers(boolean details) {
         List<Member> speakers = Talk.findAllSpeakersOn(ConferenceEvent.CURRENT);
-        renderJSON(Member.class, speakers, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
+        renderJSON(speakers, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
     public static void sponsors(boolean details) {
         List<Sponsor> sponsors = Sponsor.findOn(ConferenceEvent.CURRENT);
-        renderJSON(Sponsor.class, sponsors, details ? DETAILED_SPONSOR_SERIALIZER : SPONSOR_SERIALIZER);
+        renderJSON(sponsors, details ? DETAILED_SPONSOR_SERIALIZER : SPONSOR_SERIALIZER);
     }
 
     public static void staff(boolean details) {
         List<Staff> staff = Staff.findAll();
-        renderJSON(Staff.class, staff, details ? DETAILED_STAFF_SERIALIZER : STAFF_SERIALIZER);
+        renderJSON(staff, details ? DETAILED_STAFF_SERIALIZER : STAFF_SERIALIZER);
     }
 
     public static void members(boolean details) {
         List<Member> members = Member.findAll();
-        renderJSON(Member.class, members, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
+        renderJSON(members, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
     public static void member(long id, boolean details) {
@@ -54,7 +54,7 @@ public class ApiMembers extends JsonpController {
 
     private static void member(Member member, boolean details) {
         notFoundIfNull(member);
-        renderJSON(Member.class, member, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
+        renderJSON(member, details ? DETAILED_MEMBER_SERIALIZER : MEMBER_SERIALIZER);
     }
 
 
@@ -71,6 +71,6 @@ public class ApiMembers extends JsonpController {
     private static void favorites(Member member) {
         notFoundIfNull(member);
         List<Talk> favorites = Vote.findFavoriteTalksByMemberOn(member, ConferenceEvent.CURRENT);
-        renderJSON(Talk.class, favorites, TALK_SERIALIZER);
+        renderJSON(favorites, TALK_SERIALIZER);
     }
 }

--- a/app/controllers/api/ApiSessions.java
+++ b/app/controllers/api/ApiSessions.java
@@ -11,9 +11,16 @@ import java.util.List;
 
 public class ApiSessions extends JsonpController {
 
+    private static JsonSerializer DETAILED_SLOT_SERIALIZER = new PlanedSlotJsonSerializer(true);
+    private static JsonSerializer DETAILED_TALK_SERIALIZER = new TalkJsonSerializer(true);
+    private static JsonSerializer DETAILED_LT_SERIALIZER = new LightningTalkJsonSerializer(true);
+    private static JsonSerializer SLOT_SERIALIZER = new PlanedSlotJsonSerializer(false);
+    private static JsonSerializer TALK_SERIALIZER = new TalkJsonSerializer(false);
+    private static JsonSerializer LT_SERIALIZER = new LightningTalkJsonSerializer(false);
+
     public static void talks(boolean details) {
         Planning planning = PlanedSlot.on(ConferenceEvent.CURRENT, true);
-        renderJSON(planning.getSlots(), details ? DETAILED_SLOT_SERIALIZER : SLOT_SERIALIZER);
+        renderJSON(PlanedSlot.class, planning.getSlots(), details ? DETAILED_SLOT_SERIALIZER : SLOT_SERIALIZER);
     }
 
     public static void talk(long id, boolean details) {
@@ -23,25 +30,20 @@ public class ApiSessions extends JsonpController {
         if (slot == null) {
             slot = new PlanedSlot(talk);
         }
-        renderJSON(slot, details ? DETAILED_TALK_SERIALIZER : TALK_SERIALIZER);
+        renderJSON(PlanedSlot.class, slot, details ? DETAILED_TALK_SERIALIZER : TALK_SERIALIZER);
     }
 
     public static void lightningTalks(boolean details) {
         List<LightningTalk> talks = LightningTalk.findAllOn(ConferenceEvent.CURRENT);
-        renderJSON(talks, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
+        renderJSON(LightningTalk.class, talks, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
     }
 
     public static void lightningTalk(long id, boolean details) {
         LightningTalk talk = LightningTalk.findById(id);
         notFoundIfNull(talk);
-        renderJSON(talk, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
+        renderJSON(LightningTalk.class, talk, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
     }
 
 
-    private static JsonSerializer DETAILED_SLOT_SERIALIZER = new PlanedSlotJsonSerializer(true);
-    private static JsonSerializer DETAILED_TALK_SERIALIZER = new TalkJsonSerializer(true);
-    private static JsonSerializer DETAILED_LT_SERIALIZER = new LightningTalkJsonSerializer(true);
-    private static JsonSerializer SLOT_SERIALIZER = new PlanedSlotJsonSerializer(false);
-    private static JsonSerializer TALK_SERIALIZER = new TalkJsonSerializer(false);
-    private static JsonSerializer LT_SERIALIZER = new LightningTalkJsonSerializer(false);
+
 }

--- a/app/controllers/api/ApiSessions.java
+++ b/app/controllers/api/ApiSessions.java
@@ -20,7 +20,7 @@ public class ApiSessions extends JsonpController {
 
     public static void talks(boolean details) {
         Planning planning = PlanedSlot.on(ConferenceEvent.CURRENT, true);
-        renderJSON(PlanedSlot.class, planning.getSlots(), details ? DETAILED_SLOT_SERIALIZER : SLOT_SERIALIZER);
+        renderJSON(planning.getSlots(), details ? DETAILED_SLOT_SERIALIZER : SLOT_SERIALIZER);
     }
 
     public static void talk(long id, boolean details) {
@@ -30,18 +30,18 @@ public class ApiSessions extends JsonpController {
         if (slot == null) {
             slot = new PlanedSlot(talk);
         }
-        renderJSON(PlanedSlot.class, slot, details ? DETAILED_TALK_SERIALIZER : TALK_SERIALIZER);
+        renderJSON(slot, details ? DETAILED_TALK_SERIALIZER : TALK_SERIALIZER);
     }
 
     public static void lightningTalks(boolean details) {
         List<LightningTalk> talks = LightningTalk.findAllOn(ConferenceEvent.CURRENT);
-        renderJSON(LightningTalk.class, talks, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
+        renderJSON(talks, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
     }
 
     public static void lightningTalk(long id, boolean details) {
         LightningTalk talk = LightningTalk.findById(id);
         notFoundIfNull(talk);
-        renderJSON(LightningTalk.class, talk, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
+        renderJSON(talk, details ? DETAILED_LT_SERIALIZER : LT_SERIALIZER);
     }
 
 

--- a/app/controllers/api/JsonpController.java
+++ b/app/controllers/api/JsonpController.java
@@ -3,12 +3,11 @@ package controllers.api;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSerializer;
-
-import java.util.List;
-
 import play.mvc.Controller;
 import play.mvc.Util;
-import play.mvc.results.RenderJson;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 /**
  * Add JSONP support : render callback function if "callback" parameter provided.
@@ -18,21 +17,33 @@ public class JsonpController extends Controller {
     public static final String CALLBACK_FORMAT = "%s(%s)";
 
     @Util
-    protected static <T> void renderJSON(Class<T> type, T o, JsonSerializer<T> adapter) {
+    protected static void renderJSON(String str) {
         String callback = getCallbackParameter();
         if (callback != null) {
-            throw new RenderJson(String.format(CALLBACK_FORMAT, callback, createGson(type, adapter).toJson(o)));
+            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, str));
+        } else {
+            Controller.renderJSON(str);
         }
-        throw new RenderJson(createGson(type, adapter).toJson(o));
     }
 
     @Util
-    protected static <T> void renderJSON(Class<T> type, List<T> o, JsonSerializer<T> adapter) {
+    protected static void renderJSON(Object o, JsonSerializer<?>... adapters) {
         String callback = getCallbackParameter();
         if (callback != null) {
-            throw new RenderJson(String.format(CALLBACK_FORMAT, callback, createGson(type, adapter).toJson(o)));
+            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, createGson(adapters).toJson(o)));
+        } else {
+            Controller.renderJSON(o, adapters);
         }
-        throw new RenderJson(createGson(type, adapter).toJson(o));
+    }
+
+    @Util
+    protected static void renderJSON(Object o) {
+        String callback = getCallbackParameter();
+        if (callback != null) {
+            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, createGson().toJson(o)));
+        } else {
+            Controller.renderJSON(o);
+        }
     }
 
     private static String getCallbackParameter() {
@@ -42,10 +53,24 @@ public class JsonpController extends Controller {
         return null;
     }
 
-    private static <T> Gson createGson(Class<?> myclass, JsonSerializer<T> adapter) {
+    private static Gson createGson(JsonSerializer<?>... adapters) {
         GsonBuilder gson = new GsonBuilder();
         gson.addSerializationExclusionStrategy(new NoExposeExclusionStrategy()).create();
-        gson.registerTypeAdapter(myclass, adapter);
+        if (adapters != null) {
+            for (Object adapter : adapters) {
+                Type t = getMethod(adapter.getClass(), "serialize").getParameterTypes()[0];
+                gson.registerTypeAdapter(t, adapter);
+            }
+        }
         return gson.create();
+    }
+
+    static Method getMethod(Class<?> clazz, String name) {
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        return null;
     }
 }

--- a/app/controllers/api/JsonpController.java
+++ b/app/controllers/api/JsonpController.java
@@ -29,20 +29,22 @@ public class JsonpController extends Controller {
     @Util
     protected static void renderJSON(Object o, JsonSerializer<?>... adapters) {
         String callback = getCallbackParameter();
+        String json = createGson(adapters).toJson(o);
         if (callback != null) {
-            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, createGson(adapters).toJson(o)));
+            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, json));
         } else {
-            Controller.renderJSON(o, adapters);
+            Controller.renderJSON(json);
         }
     }
 
     @Util
     protected static void renderJSON(Object o) {
         String callback = getCallbackParameter();
+        String json = createGson().toJson(o);
         if (callback != null) {
-            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, createGson().toJson(o)));
+            Controller.renderJSON(String.format(CALLBACK_FORMAT, callback, json));
         } else {
-            Controller.renderJSON(o);
+            Controller.renderJSON(json);
         }
     }
 

--- a/app/controllers/api/NoExposeExclusionStrategy.java
+++ b/app/controllers/api/NoExposeExclusionStrategy.java
@@ -1,0 +1,33 @@
+package controllers.api;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom exclusion strategy
+ */
+public class NoExposeExclusionStrategy implements ExclusionStrategy {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD })
+    public @interface NoExpose {
+        // Field tag only annotation
+    }
+
+    public NoExposeExclusionStrategy() {
+    }
+
+    public boolean shouldSkipClass(Class<?> clazz) {
+        return (false);
+    }
+
+    public boolean shouldSkipField(FieldAttributes f) {
+        return f.getAnnotation(NoExpose.class) != null;
+    }
+
+}

--- a/app/controllers/api/SessionJsonSerializer.java
+++ b/app/controllers/api/SessionJsonSerializer.java
@@ -38,21 +38,19 @@ public abstract class SessionJsonSerializer {
         }
 
         if (CollectionUtils.size(session.speakers) != 0) {
-            if (details) {
-                JsonArray speakers = new JsonArray();
-                for (Member s : session.speakers) {
-                    JsonObject speaker = new JsonObject();
-                    speaker.addProperty("id", s.id);
+            JsonArray speakers = new JsonArray();
+            for (Member s : session.speakers) {
+                JsonObject speaker = new JsonObject();
+                speaker.addProperty("id", s.id);
+                if(details) {
                     speaker.addProperty("firstname", s.firstname);
                     speaker.addProperty("lastname", s.lastname);
                     speaker.addProperty("urlimage", s.getUrlImage());
                     speaker.addProperty("url", ApiUrl.getMemberUrl(s.id));
-                    speakers.add(speaker);
                 }
-                result.add("speakers", speakers);
-            } else {
-                result.add("speakers", JSON.toJsonArrayOfIds(session.speakers));
+                speakers.add(speaker);
             }
+            result.add("speakers", speakers);
         }
 
         return result;

--- a/app/controllers/api/SessionJsonSerializer.java
+++ b/app/controllers/api/SessionJsonSerializer.java
@@ -38,19 +38,23 @@ public abstract class SessionJsonSerializer {
         }
 
         if (CollectionUtils.size(session.speakers) != 0) {
-            JsonArray speakers = new JsonArray();
-            for (Member s : session.speakers) {
-                JsonObject speaker = new JsonObject();
-                speaker.addProperty("id", s.id);
-                if(details) {
+            if(details) {
+                JsonArray speakers = new JsonArray();
+                for (Member s : session.speakers) {
+                    JsonObject speaker = new JsonObject();
+                    speaker.addProperty("id", s.id);
                     speaker.addProperty("firstname", s.firstname);
                     speaker.addProperty("lastname", s.lastname);
                     speaker.addProperty("urlimage", s.getUrlImage());
                     speaker.addProperty("url", ApiUrl.getMemberUrl(s.id));
+                    speakers.add(speaker);
                 }
-                speakers.add(speaker);
+                result.add("speakers", speakers);
             }
-            result.add("speakers", speakers);
+            else {
+                result.add("speakers", JSON.toJsonArrayOfIds(session.speakers));
+            }
+
         }
 
         return result;

--- a/app/models/Account.java
+++ b/app/models/Account.java
@@ -13,6 +13,8 @@ import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+
+import controllers.api.NoExposeExclusionStrategy;
 import models.activity.StatusActivity;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -33,6 +35,7 @@ public abstract class Account extends Model implements Comparable<Account> {
     
     @Required
     @ManyToOne(optional = false)
+    @NoExposeExclusionStrategy.NoExpose
     public Member member;
 
     // Authentication provider : linkit, twitter, google, ...

--- a/app/models/Member.java
+++ b/app/models/Member.java
@@ -5,6 +5,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import controllers.JobFetchUserTimeline;
 import controllers.JobMajUserRegisteredTicketing;
+import controllers.api.NoExposeExclusionStrategy;
 import helpers.JavaExtensions;
 import helpers.badge.BadgeComputationContext;
 import helpers.badge.BadgeComputer;
@@ -144,6 +145,7 @@ public class Member extends Model implements Lookable, Comparable<Member> {
     public Set<Badge> badges = EnumSet.noneOf(Badge.class);
 
     @ManyToMany(mappedBy="speakers")
+    @NoExposeExclusionStrategy.NoExpose
     public Set<Session> sessions = new HashSet<Session>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/app/models/Member.java
+++ b/app/models/Member.java
@@ -127,15 +127,18 @@ public class Member extends Model implements Lookable, Comparable<Member> {
      * Members he follows
      */
     @ManyToMany
+    @NoExposeExclusionStrategy.NoExpose
     public Set<Member> links = new HashSet<Member>();
     /**
      * Members who follow him : reverse-mapping of {@link Member#links}
      */
     @ManyToMany(mappedBy = "links")
+    @NoExposeExclusionStrategy.NoExpose
     public Set<Member> linkers = new HashSet<Member>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @MapKey(name="provider")
+    @NoExposeExclusionStrategy.NoExpose
     public Map<ProviderType,Account> accounts = new EnumMap<ProviderType, Account>(ProviderType.class);
 
     @ManyToMany(cascade = CascadeType.PERSIST)

--- a/app/models/Session.java
+++ b/app/models/Session.java
@@ -7,6 +7,8 @@ import controllers.Mails;
 import java.util.*;
 import javax.annotation.Nullable;
 import javax.persistence.*;
+
+import controllers.api.NoExposeExclusionStrategy;
 import models.activity.Activity;
 import models.activity.CommentSessionActivity;
 import models.activity.LookSessionActivity;
@@ -68,6 +70,7 @@ public abstract class Session extends Model implements Lookable, Comparable<Sess
 
     @ManyToMany
     @Required
+    @NoExposeExclusionStrategy.NoExpose
     public Set<Member> speakers = new HashSet<Member>();
 
     @ManyToMany(cascade = CascadeType.PERSIST)
@@ -79,6 +82,7 @@ public abstract class Session extends Model implements Lookable, Comparable<Sess
     public List<SessionComment> comments = new ArrayList<SessionComment>();
 
     @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+    @NoExposeExclusionStrategy.NoExpose
     public List<Vote> votes;
 
     /** Number of consultation */

--- a/app/models/SharedLink.java
+++ b/app/models/SharedLink.java
@@ -2,6 +2,8 @@ package models;
 
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+
+import controllers.api.NoExposeExclusionStrategy;
 import models.activity.SharedLinkActivity;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -28,6 +30,7 @@ public class SharedLink extends Model {
     public String URL;
 
     @ManyToOne(optional = false)
+    @NoExposeExclusionStrategy.NoExpose
     public Member member;
 
     public SharedLink(String name, String URL) {


### PR DESCRIPTION
These method signatures are the one inherited by Play's `Controller` methods, thus making the code from `ApiSessions` and `ApiMembers` natively compatible with Play, `JsonpController` being in heritage chain or not.

THIS PR IS AIMED TO BE MERGED BY you @javamind in your own javamind/linkit repo, I'M NOT SAYING THAT YOU SHOULD MERGE mix-it/linkit#388.
